### PR TITLE
Add indentation detection

### DIFF
--- a/PowerEditor/src/Notepad_plus.cpp
+++ b/PowerEditor/src/Notepad_plus.cpp
@@ -1173,6 +1173,7 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
                 }
             }
             *dest = '\0';
+            _pEditView->getCurrentBuffer()->setTabSize(tabWidth);
             break;
         }
         case space2TabLeading:
@@ -1279,6 +1280,7 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
                     ++newCurrentPos;
             }
             *dest = '\0';
+            _pEditView->getCurrentBuffer()->setTabSize(0);
             break;
         }
     }
@@ -1294,6 +1296,9 @@ void Notepad_plus::wsTabConvert(spaceTab whichWay)
         _pEditView->fold(folding[i], false);
 
     _pEditView->execute(SCI_ENDUNDOACTION);
+
+    // update indentation
+    _pEditView->setTabSettings();
 
     // clean up
     delete [] source;

--- a/PowerEditor/src/NppBigSwitch.cpp
+++ b/PowerEditor/src/NppBigSwitch.cpp
@@ -2046,7 +2046,7 @@ LRESULT Notepad_plus::process(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPa
 		case NPPM_INTERNAL_SETTING_TAB_REPLCESPACE:
 		case NPPM_INTERNAL_SETTING_TAB_SIZE:
 		{
-            _pEditView->setTabSettings(_pEditView->getCurrentBuffer()->getCurrentLang());
+            _pEditView->setTabSettings();
 			break;
 		}
 

--- a/PowerEditor/src/ScitillaComponent/Buffer.cpp
+++ b/PowerEditor/src/ScitillaComponent/Buffer.cpp
@@ -47,7 +47,7 @@ const int LF = 0x0A;
 
 Buffer::Buffer(FileManager * pManager, BufferID id, Document doc, DocFileStatus type, const TCHAR *fileName)	//type must be either DOC_REGULAR or DOC_UNNAMED
 	: _pManager(pManager), _id(id), _isDirty(false), _doc(doc), _isFileReadOnly(false), _isUserReadOnly(false), _recentTag(-1), _references(0),
-	_canNotify(false), _timeStamp(0), _needReloading(false), _encoding(-1), _backupFileName(TEXT("")), _isModified(false), _isLoadedDirty(false), _lang(L_TEXT)
+	_canNotify(false), _timeStamp(0), _needReloading(false), _encoding(-1), _tabSize(-1), _backupFileName(TEXT("")), _isModified(false), _isLoadedDirty(false), _lang(L_TEXT)
 {
 	NppParameters *pNppParamInst = NppParameters::getInstance();
 	const NewDocDefaultSettings & ndds = (pNppParamInst->getNppGUI()).getNewDocDefaultSettings();
@@ -478,8 +478,9 @@ BufferID FileManager::loadFile(const TCHAR * filename, Document doc, int encodin
 
 	Utf8_16_Read UnicodeConvertor;	//declare here so we can get information after loading is done
 
+	int tabSize = -1;
 	formatType format;
-	bool res = loadFileData(doc, backupFileName?backupFileName:fullpath, &UnicodeConvertor, L_TEXT, encoding, &format);
+	bool res = loadFileData(doc, backupFileName?backupFileName:fullpath, &UnicodeConvertor, L_TEXT, encoding, tabSize, &format);
 	if (res) 
 	{
 		Buffer * newBuf = new Buffer(this, _nextBufferID, doc, DOC_REGULAR, fullpath);
@@ -539,6 +540,8 @@ BufferID FileManager::loadFile(const TCHAR * filename, Document doc, int encodin
 			buf->setFormat(format);
 		}
 
+		buf->setTabSize(tabSize);
+
 		//determine buffer properties
 		++_nextBufferID;
 		return id;
@@ -558,8 +561,9 @@ bool FileManager::reloadBuffer(BufferID id)
 	Utf8_16_Read UnicodeConvertor;
 	buf->_canNotify = false;	//disable notify during file load, we dont want dirty to be triggered
 	int encoding = buf->getEncoding();
+	int tabSize = -1;
 	formatType format;
-	bool res = loadFileData(doc, buf->getFullPathName(), &UnicodeConvertor, buf->getLangType(), encoding, &format);
+	bool res = loadFileData(doc, buf->getFullPathName(), &UnicodeConvertor, buf->getLangType(), encoding, tabSize, &format);
 	buf->_canNotify = true;
 	if (res) 
 	{
@@ -582,6 +586,7 @@ bool FileManager::reloadBuffer(BufferID id)
 			buf->setFormat(format);
 			buf->setUnicodeMode(uniCookie);
 		}
+		buf->setTabSize(tabSize);
 	}
 	return res;
 }
@@ -1131,7 +1136,7 @@ int FileManager::detectCodepage(char* buf, size_t len)
 	return codepage;
 }
 
-bool FileManager::loadFileData(Document doc, const TCHAR * filename, Utf8_16_Read * UnicodeConvertor, LangType language, int & encoding, formatType *pFormat)
+bool FileManager::loadFileData(Document doc, const TCHAR * filename, Utf8_16_Read * UnicodeConvertor, LangType language, int & encoding, int & tabSize, formatType *pFormat)
 {
 	const int blockSize = 128 * 1024;	//128 kB
 	char data[blockSize+8];
@@ -1201,9 +1206,47 @@ bool FileManager::loadFileData(Document doc, const TCHAR * filename, Utf8_16_Rea
 		bool isFirstTime = true;
 		int incompleteMultibyteChar = 0;
 
+		// discover indentation
+		bool newline = true;
+		int indent = 0; // current line indentation
+		int tabSizes[9] = { 0, 0, 0, 0, 0, 0, 0, 0, 0 }; // number of lines with corresponding indentation (index 0 - tab)
+		int prevIndent = 0; // previous line indentation
+		int prevTabSize = -1; // previous line tab size
+
 		do {
 			lenFile = fread(data+incompleteMultibyteChar, 1, blockSize-incompleteMultibyteChar, fp) + incompleteMultibyteChar;
 			if (lenFile <= 0) break;
+
+			// discover indentation
+			for (int i = 0; i < int(lenFile); i++) {
+				char ch = data[i];
+				if (ch == '\r' || ch == '\n') {
+					indent = 0;
+					newline = true;
+				} else if (newline && ch == ' ') {
+					indent++;
+				} else if (newline) {
+					if (indent) {
+						if (indent == prevIndent && prevTabSize != -1) {
+							tabSizes[prevTabSize]++;
+						} else if (indent > prevIndent && prevIndent != -1) {
+							if (indent - prevIndent <= 8) {
+								prevTabSize = indent - prevIndent;
+								tabSizes[prevTabSize]++;
+							} else {
+								prevTabSize = -1;
+							}
+						}
+						prevIndent = indent;
+					} else if (ch == '\t') {
+						tabSizes[0]++;
+						prevIndent = -1;
+					} else {
+						prevIndent = 0;
+					}
+					newline = false;
+				}
+			}
 
             // check if file contain any BOM
             if (isFirstTime) 
@@ -1254,6 +1297,13 @@ bool FileManager::loadFileData(Document doc, const TCHAR * filename, Utf8_16_Rea
 			}
 			
 		} while (lenFile > 0);
+
+		// maximum non-zero indent
+		for (int j = 0; j <= 8; j++) {
+			if (tabSizes[j] && (tabSize == -1 || tabSizes[j] > tabSizes[tabSize])) {
+				tabSize = j;
+			}
+		}
 	} __except(EXCEPTION_EXECUTE_HANDLER) {  //TODO: should filter correctly for other exceptions; the old filter(GetExceptionCode(), GetExceptionInformation()) was only catching access violations
 		::MessageBox(NULL, TEXT("File is too big to be opened by Notepad++"), TEXT("File open problem"), MB_OK|MB_APPLMODAL);
 		success = false;

--- a/PowerEditor/src/ScitillaComponent/Buffer.h
+++ b/PowerEditor/src/ScitillaComponent/Buffer.h
@@ -120,7 +120,7 @@ private:
 	size_t _nrBufs;
 	int detectCodepage(char* buf, size_t len);
 
-	bool loadFileData(Document doc, const TCHAR * filename, Utf8_16_Read * UnicodeConvertor, LangType language, int & encoding, formatType *pFormat = NULL);
+	bool loadFileData(Document doc, const TCHAR * filename, Utf8_16_Read * UnicodeConvertor, LangType language, int & encoding, int & tabSize, formatType *pFormat = NULL);
 };
 
 #define MainFileManager FileManager::getInstance()
@@ -225,6 +225,14 @@ public :
 	void setEncoding(int encoding) {
 		_encoding = encoding;
         doNotify(BufferChangeUnicode | BufferChangeDirty);
+	};
+
+	int getTabSize() const {
+		return _tabSize;
+	};
+
+	void setTabSize(int tabSize) {
+		_tabSize = tabSize;
 	};
 
 	DocFileStatus getStatus() const {
@@ -344,6 +352,7 @@ private :
 	formatType _format;
 	UniMode _unicodeMode;
 	int _encoding;
+	int _tabSize;
 	bool _isUserReadOnly;
 	bool _needLexer;	//initially true
 	//these properties have to be duplicated because of multiple references

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.cpp
@@ -2882,20 +2882,33 @@ void ScintillaEditView::runMarkers(bool doHide, int searchStart, bool endOfDoc, 
 	}
 }
 
-
 void ScintillaEditView::setTabSettings(Lang *lang)
 {
-    if (lang && lang->_tabSize != -1 && lang->_tabSize != 0)
-    {
-        execute(SCI_SETTABWIDTH, lang->_tabSize);
-        execute(SCI_SETUSETABS, !lang->_isTabReplacedBySpace);
-    }
-    else
-    {
-        const NppGUI & nppgui = _pParameter->getNppGUI();
-        execute(SCI_SETTABWIDTH, nppgui._tabSize);
-		execute(SCI_SETUSETABS, !nppgui._tabReplacedBySpace);
-    }
+	if (!lang)
+		lang = getCurrentBuffer()->getCurrentLang();
+	int detectedTabSize = _currentBuffer->getTabSize();
+	int tabSize;
+	int isTabReplacedBySpace;
+
+	if (lang && lang->_tabSize > 0) {
+		tabSize = lang->_tabSize;
+		isTabReplacedBySpace = lang->_isTabReplacedBySpace;
+	} else {
+		const NppGUI & nppgui = (NppParameters::getInstance())->getNppGUI();
+		tabSize = nppgui._tabSize;
+		isTabReplacedBySpace = nppgui._tabReplacedBySpace;
+	}
+	
+	if (detectedTabSize == 0) {
+		execute(SCI_SETTABWIDTH, tabSize);
+		execute(SCI_SETUSETABS, 1);
+	} else if (detectedTabSize != -1) {
+		execute(SCI_SETTABWIDTH, detectedTabSize);
+		execute(SCI_SETUSETABS, 0);
+	} else {
+		execute(SCI_SETTABWIDTH, tabSize);
+		execute(SCI_SETUSETABS, !isTabReplacedBySpace);
+	}
 }
 
 void ScintillaEditView::insertNewLineAboveCurrentLine()

--- a/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
+++ b/PowerEditor/src/ScitillaComponent/ScintillaEditView.h
@@ -625,7 +625,7 @@ public:
 	};
 	
 	void setHotspotStyle(Style& styleToSet);
-    void setTabSettings(Lang *lang);
+    void setTabSettings(Lang *lang = 0);
 	bool isWrapRestoreNeeded() const {return _wrapRestoreNeeded;};
 	void setWrapRestoreNeeded(bool isWrapRestoredNeeded) {_wrapRestoreNeeded = isWrapRestoredNeeded;};
 


### PR DESCRIPTION
the patch is at https://github.com/mirror/notepadplus/pull/1
## indentation should be detected

users take for granted that the app detect EOL style and encoding. it should be equally unquestionable that it detects indentation style because it's an equally big time waster when it doesn't
## svn

commit in svn with

```
curl https://github.com/mirror/notepadplus/pull/1.diff > patch.diff
patch -p1 < patch.diff
```

copy the commit message from https://github.com/mirror/notepadplus/pull/1/commits

set me as author

```
svn propset --revprop svn:author 'john-peterson'
```
## sourceforge

a pull request notification is at https://sourceforge.net/p/notepad-plus/patches/438 https://sourceforge.net/p/notepad-plus/patches/645
